### PR TITLE
Correct argv passed to gmsh.initialize()

### DIFF
--- a/src/StellaGmsh.jl
+++ b/src/StellaGmsh.jl
@@ -104,7 +104,9 @@ function with_gmsh(
 )
 
     # If user provides argv, prepend the program name to match intended behavior
-    !isempty(argv) && append!(["gmsh"], argv)
+    if !isempty(argv) 
+        argv = append!(["gmsh"], argv)
+    end
 
     gmsh.initialize(argv, read_config_files, run)
     gmsh.model.add(model_name)

--- a/src/StellaGmsh.jl
+++ b/src/StellaGmsh.jl
@@ -78,6 +78,18 @@ mesh = G.with_gmsh() do
     # Return mesh from `do` block
     mesh
 end
+
+Forward GMSH-specific arguments (see [here](https://gmsh.info/doc/texinfo/#Gmsh-command_002dline-interface)), 
+such as suppressing non-error output:
+
+```julia
+import StellaGmsh as G
+
+# -v 0 sets verbosity to 0: silent except for fatal errors
+mesh = G.with_gmsh(argv=["-v", "0"]) do
+    G.Box((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+    G.mesh()
+end
 ```
 
 Geometry-geometry operations include `+` for fusing geometries, `-` for subtracting (cutting),
@@ -90,6 +102,9 @@ function with_gmsh(
     run=false,
     model_name="StellaGmshModel",
 )
+
+    # If user provides argv, prepend the program name to match intended behavior
+    !isempty(argv) && append!(["gmsh"], argv)
 
     gmsh.initialize(argv, read_config_files, run)
     gmsh.model.add(model_name)


### PR DESCRIPTION
The way we forward `argv` vs how it is handled via the gmsh cli is different.

Gmsh expects argv[0] to be the program name. To most users, this is unexpected, as they will be expecting cases like 

```julia
import StellaGmsh as G
G.with_gmsh(argv=["-v", "0"]) do
...
end
```

to suppress output. This does not happen.

This PR adds a check for if `argv` is not empty, and if so, prepend the program name so that `argv` is handled by gmsh correctly. In the [tutorials](https://gitlab.onelab.info/gmsh/gmsh/-/blob/master/tutorials/julia/t2.jl?ref_type=heads#L13), the same is done, so that `julia my_script.jl -v 0` would behave the same as `gmsh -v 0 my_script.geo`. An example has been added to the docstring also.